### PR TITLE
feat: add .ToString() implementation on ProblemDetails

### DIFF
--- a/Source/RESTyard.Client/Exceptions/ProblemDetails.cs
+++ b/Source/RESTyard.Client/Exceptions/ProblemDetails.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace RESTyard.Client.Exceptions
 {
@@ -51,5 +52,15 @@ namespace RESTyard.Client.Exceptions
         /// In particular, complex types or collection types may not round-trip to the original type when using the built-in JSON or XML formatters.
         /// </remarks>
         public IDictionary<string, object?> Extensions { get; } = new Dictionary<string, object?>(StringComparer.Ordinal);
+
+        public override string ToString()
+        {
+            return $"{base.ToString()}: Status={Status}, Title={Title}, Detail={Detail}, Type={Type}, Instance={Instance}, Extensions={Format(Extensions)}";
+
+            static string Format(IDictionary<string, object?> extensions)
+            {
+                return string.Join("|", extensions.Select(kvp => $"{kvp.Key}:{kvp.Value}"));
+            }
+        }
     }
 }


### PR DESCRIPTION
When using the AwesomeAssertion extensions on HypermediaResult, e.g. in an integration test, a call to `.Should().BeOk()` on a `HypermediaResult.Error { HypermediaProblem.ProblemDetails_ }` will output something similar to

```
Expected object to be Ok, but found "Error ProblemDetails_ { Details = RESTyard.Client.Exceptions.ProblemDetails }"
```

which does not give any indication as to what actually failed, and requires debugging the test.
Instead with this `.ToString()` implementation, the output looks like this

```
Expected object to be Ok, but found "Error ProblemDetails_ { Details = RESTyard.Client.Exceptions.ProblemDetails: Status=400, Title=Entity already exists, Detail=Entity with key 'ABC' already exists, Type=, Instance=, Extensions=Uri:https://some.website/api/path/to/entity/ABC }"
```