### PR TITLE
Fix uri can be invalid in some cases wich throws

### DIFF
--- a/Source/RESTyard.AspNetCore.Test/WebApi/RouteResolver/KeyFromUriServiceTests.cs
+++ b/Source/RESTyard.AspNetCore.Test/WebApi/RouteResolver/KeyFromUriServiceTests.cs
@@ -24,7 +24,7 @@ public class KeyFromUriServiceTests
     }
 
     [TestMethod]
-    public void Test()
+    public void TestKeyExtraction()
     {
         // Given
         var apiExplorer = CreateExplorer(["Test/{intKey:int}/{key}"]);
@@ -177,6 +177,41 @@ public class KeyFromUriServiceTests
         var result = values.Should().BeOk().Which;
         result.IntKey.Should().Be(15);
         result.GuidKey.Should().Be(new Guid(guid));
+    }
+    
+    [TestMethod]
+    public void IsErrorResult_RelativeUri()
+    {
+        // Given
+        var apiExplorer = CreateExplorer(["Test/AllTypes/{intKey}/{guidKey}"]);
+        var service = new KeyFromUriService(apiExplorer);
+        // relative uris are accepted by STJ, e.g. when parsing a body containing Uri
+        Uri.TryCreate("/abc/test",UriKind.RelativeOrAbsolute, out var uri);
+        
+        // When
+        var values = service.GetKeyFromUri<AllKeyTypesHto, AllKeyTypesHto.KeyRecord>(uri!);
+        
+        // Then
+        var result = values.Should().BeError("Uri must be absolute").Which;
+        result.Should().Contain("is not absolute");
+    }
+    
+    [TestMethod]
+    public void IsErrorResult_InvalidPathUri()
+    {
+        // Given
+        var apiExplorer = CreateExplorer(["Test/AllTypes/{intKey}/{guidKey}"]);
+        var service = new KeyFromUriService(apiExplorer);
+        
+        // relative uris are accepted by STJ, e.g. when parsing a body containing Uri
+        Uri.TryCreate("abc/test",UriKind.RelativeOrAbsolute, out Uri? uri);
+        
+        // When
+        var values = service.GetKeyFromUri<AllKeyTypesHto, AllKeyTypesHto.KeyRecord>(uri!);
+        
+        // Then
+        var result = values.Should().BeError("Uri must be absolute").Which;
+        result.Should().Contain("is not absolute");
     }
 
     [HypermediaObject(Classes = [nameof(TestHto)])]

--- a/Source/RESTyard.AspNetCore/RESTyard.AspNetCore.csproj
+++ b/Source/RESTyard.AspNetCore/RESTyard.AspNetCore.csproj
@@ -9,7 +9,7 @@
       $(VersionSuffix)
     </VersionSuffixLocal>
 
-    <Version>6.0.1$(VersionSuffixLocal)</Version>
+    <Version>6.0.2$(VersionSuffixLocal)</Version>
     <TargetFramework>net8.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>

--- a/Source/RESTyard.AspNetCore/WebApi/RouteResolver/KeyFromUriService.cs
+++ b/Source/RESTyard.AspNetCore/WebApi/RouteResolver/KeyFromUriService.cs
@@ -25,6 +25,11 @@ public class KeyFromUriService : IKeyFromUriService
     public Result<TKey> GetKeyFromUri<THto, TKey>(Uri uri)
         where THto : IHypermediaObject
     {
+        if (!uri.IsAbsoluteUri)
+        {
+            return Result.Error<TKey>($"URI '{uri}' is not absolute. Required for key deconstruction.");
+        }
+        
         var result =
             from matchers in GetTemplateMatchers<THto>()
             from values in GetValuesFromRequest(matchers, uri)


### PR DESCRIPTION
Some requests lead to (silent) invalid URIs when parese by STJ. They do not contain a schema for example.
This leads to KeyFromUriService throwing an exception but this should be a Result.Error

public class MyRequest
{
    public Uri CallbackUrl { get; set; }
}

